### PR TITLE
Feature/1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.0.1
+
+* Add test to ensure that every symbol from the Magic: The Gathering comprehensive rules has a corresponding item in `mtgSymbology`
+    * The source of truth for these symbols is https://api.scryfall.com/symbology
+
 ### 1.0.0
 
 * Initial stable release

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: mtg_symbology
 description: "Easily display Magic: The Gathering symbols as Flutter SVG widgets."
 repository: https://github.com/zmuranaka/mtg_symbology
 issue_tracker: https://github.com/zmuranaka/mtg_symbology/issues
-version: 1.0.0
+version: 1.0.1
 
 environment:
   sdk: ^3.6.0
@@ -17,6 +17,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^5.0.0
+  http: ^1.4.0
   test: ^1.25.15
 
 flutter:

--- a/test/mtg_symbology_test.dart
+++ b/test/mtg_symbology_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
 import 'package:mtg_symbology/mtg_symbology.dart';
 import 'package:test/test.dart';
 
@@ -19,6 +22,27 @@ void main() {
         expect(mtgSymbology['white mana'], isNull);
         expect(mtgSymbology['{w}'], isNull);
         expect(mtgSymbology['{W}'], isNotNull);
+      },
+    );
+
+    test(
+      'mtgSymbology accounts for all symbols in Magic: The Gathering '
+      'comprehensive rules, using Scryfall as the source of truth',
+      () async {
+        final response = await http.get(
+          Uri.parse('https://api.scryfall.com/symbology'),
+          headers: {
+            'User-Agent': 'mtg_symbology/1',
+            'Accept': 'application/json',
+          },
+        );
+        expect(response.statusCode, equals(200));
+        final decoded = jsonDecode(response.body) as Map<String, dynamic>;
+        expect(decoded.containsKey('data'), isTrue);
+        final data = (decoded['data'] as List).cast<Map<String, dynamic>>();
+        expect(data.length, equals(mtgSymbology.length));
+        final symbols = data.map((s) => s['symbol']).toSet();
+        expect(symbols, equals(mtgSymbology.keys.toSet()));
       },
     );
   });


### PR DESCRIPTION
* Add test to ensure that every symbol from the Magic: The Gathering comprehensive rules has a corresponding item in https://github.com/zmuranaka/mtg_symbology/blob/5296f1f183a30cd7db9b3aad59b8a38a4ddfa69e/lib/mtg_symbology.dart#L6
    * The source of truth for these symbols is https://api.scryfall.com/symbology