### PR TITLE
1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 1.0.5 - March 19, 2026
 
+* Upgrade [flutter_svg](https://pub.dev/packages/flutter_svg) dependency version
 * Make minimum supported SDK version Flutter 3.35/Dart 3.9 - in line with [flutter_svg](https://github.com/flutter/packages/blob/8dcfd1186ef968be1398f80432f94bb0a36e6d9e/third_party/packages/flutter_svg/pubspec.yaml#L8-L9)
 * Upgrade [test](https://pub.dev/packages/test) dev dependency version
 * Upgrade [very_good_analysis](https://pub.dev/packages/very_good_analysis) dev dependency version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.0.5 - March 19, 2026
+
+* Make minimum supported SDK version Flutter 3.35/Dart 3.9 - in line with [flutter_svg](https://github.com/flutter/packages/blob/8dcfd1186ef968be1398f80432f94bb0a36e6d9e/third_party/packages/flutter_svg/pubspec.yaml#L8-L9)
+* Upgrade [test](https://pub.dev/packages/test) dev dependency version
+* Upgrade [very_good_analysis](https://pub.dev/packages/very_good_analysis) dev dependency version
+
 ### 1.0.4 - February 22, 2026
 
 * Upgrade [test](https://pub.dev/packages/test) dev dependency version

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,21 +2,21 @@ name: mtg_symbology
 description: "Easily display Magic: The Gathering symbols as Flutter SVG widgets."
 repository: https://github.com/zmuranaka/mtg_symbology
 issue_tracker: https://github.com/zmuranaka/mtg_symbology/issues
-version: 1.0.4
+version: 1.0.5
 
 environment:
-  sdk: ^3.8.0
-  flutter: ">=3.32.0"
+  sdk: ^3.9.0
+  flutter: ">=3.35.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_svg: ^2.2.3
+  flutter_svg: ^2.2.4
 
 dev_dependencies:
   http: ^1.6.0
-  test: ^1.29.0
-  very_good_analysis: ^10.0.0
+  test: ^1.31.0
+  very_good_analysis: ^10.2.0
 
 flutter:
   assets:


### PR DESCRIPTION
* Make minimum supported SDK version Flutter 3.35/Dart 3.9 - in line with [flutter_svg](https://github.com/flutter/packages/blob/8dcfd1186ef968be1398f80432f94bb0a36e6d9e/third_party/packages/flutter_svg/pubspec.yaml#L8-L9)
* Upgrade [test](https://pub.dev/packages/test) dev dependency version
* Upgrade [very_good_analysis](https://pub.dev/packages/very_good_analysis) dev dependency version